### PR TITLE
chore: migrate Jenkinsfile to jenkins-lib-ui@1.0.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'zapp-jenkins-lib@1.0.3',
+    identifier: 'jenkins-lib-ui@1.0.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
     ])
 )
 


### PR DESCRIPTION
Migrates Jenkinsfile from deprecated `zapp-jenkins-lib@1.0.3` to `jenkins-lib-ui@1.0.4`.

## Changes

- **Library migration**: Updated to `jenkins-lib-ui@1.0.4` from `zapp-jenkins-lib@1.0.3`
- **Repository update**: Changed from `jenkins-zapp-lib` to `jenkins-lib-ui`
- **Parameter ordering**: Reordered `credentialsId` before `remote` for consistency
- **Function preservation**: All `zappPipeline()` parameters preserved unchanged

```groovy
// Before
library(
    identifier: 'zapp-jenkins-lib@1.0.3',
    retriever: modernSCM([
        $class: 'GitSCMSource',
        remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
        credentialsId: 'jenkins-integration-with-github-account'
    ])
)

// After
library(
    identifier: 'jenkins-lib-ui@1.0.4',
    retriever: modernSCM([
        $class: 'GitSCMSource',
        credentialsId: 'jenkins-integration-with-github-account',
        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
    ])
)
```

Resolve: [IN-959](https://zextras.atlassian.net/browse/IN-959)

[IN-959]: https://zextras.atlassian.net/browse/IN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ