### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dist-ssr
 zextras-*.tgz
 
 coverage
+
+.worktrees

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
     ])
 )
 
-zappPipeline()
+uiPipeline()


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

### Changes

- Replace `library()` block: `jenkins-lib-ui@1.0.13` → `jenkins-lib-common@v2.4.3`
- Rename function call: `zappPipeline()` → `uiPipeline()` (parameters are identical)

### References

- `jenkins-lib-ui` repo has been merged into `jenkins-lib-common`
- `uiPipeline()` is a drop-in replacement for `zappPipeline()` with identical parameters