### PR TITLE
chore(deps): weekly dependencies update 2026-06-04

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
 	"dependencies": {
 		"@emotion/react": "11.14.0",
 		"@emotion/styled": "11.14.1",
-		"@zextras/carbonio-design-system": "12.0.2",
-		"graphql": "16.10.0",
-		"i18next": "25.6.0",
-		"i18next-browser-languagedetector": "8.2.0",
-		"i18next-http-backend": "3.0.5",
+		"@zextras/carbonio-design-system": "12.0.4",
+		"graphql": "16.14.1",
+		"i18next": "25.10.10",
+		"i18next-browser-languagedetector": "8.2.1",
+		"i18next-http-backend": "3.0.6",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"react-i18next": "16.0.0"
+		"react-i18next": "16.6.6"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "20.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,20 +15,20 @@ importers:
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@zextras/carbonio-design-system':
-        specifier: 12.0.2
-        version: 12.0.2(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(date-fns@3.6.0)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 12.0.4
+        version: 12.0.4(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(date-fns@3.6.0)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
-        specifier: 16.10.0
-        version: 16.10.0
+        specifier: 16.14.1
+        version: 16.14.1
       i18next:
-        specifier: 25.6.0
-        version: 25.6.0(typescript@5.8.2)
+        specifier: 25.10.10
+        version: 25.10.10(typescript@5.8.2)
       i18next-browser-languagedetector:
-        specifier: 8.2.0
-        version: 8.2.0
+        specifier: 8.2.1
+        version: 8.2.1
       i18next-http-backend:
-        specifier: 3.0.5
-        version: 3.0.5
+        specifier: 3.0.6
+        version: 3.0.6
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -36,8 +36,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-i18next:
-        specifier: 16.0.0
-        version: 16.0.0(i18next@25.6.0(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
+        specifier: 16.6.6
+        version: 16.6.6(i18next@25.10.10(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)
     devDependencies:
       '@commitlint/cli':
         specifier: 20.5.2
@@ -56,25 +56,25 @@ importers:
         version: 9.9.0
       '@graphql-codegen/add':
         specifier: 6.0.1
-        version: 6.0.1(graphql@16.10.0)
+        version: 6.0.1(graphql@16.14.1)
       '@graphql-codegen/cli':
         specifier: 6.3.1
-        version: 6.3.1(@types/node@25.9.1)(graphql@16.10.0)(typescript@5.8.2)
+        version: 6.3.1(@types/node@25.9.1)(graphql@16.14.1)(typescript@5.8.2)
       '@graphql-codegen/typed-document-node':
         specifier: 6.1.8
-        version: 6.1.8(graphql@16.10.0)
+        version: 6.1.8(graphql@16.14.1)
       '@graphql-codegen/typescript':
         specifier: 5.0.10
-        version: 5.0.10(graphql@16.10.0)
+        version: 5.0.10(graphql@16.14.1)
       '@graphql-codegen/typescript-operations':
         specifier: 5.1.0
-        version: 5.1.0(graphql@16.10.0)
+        version: 5.1.0(graphql@16.14.1)
       '@graphql-eslint/eslint-plugin':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@25.9.1)(eslint@8.57.1)(graphql@16.10.0)(typescript@5.8.2)
+        version: 4.3.0(@types/node@25.9.1)(eslint@8.57.1)(graphql@16.14.1)(typescript@5.8.2)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
-        version: 3.2.0(graphql@16.10.0)
+        version: 3.2.0(graphql@16.14.1)
       '@semantic-release/changelog':
         specifier: 6.0.3
         version: 6.0.3(semantic-release@25.0.3(typescript@5.8.2))
@@ -699,6 +699,9 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/dom@1.6.12':
+    resolution: {integrity: sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
@@ -708,11 +711,11 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.27.19':
-    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
     peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -1346,8 +1349,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rollup/rollup-linux-x64-gnu@4.53.3':
+    resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1389,8 +1392,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+  '@rollup/rollup-win32-x64-msvc@4.53.3':
+    resolution: {integrity: sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==}
     cpu: [x64]
     os: [win32]
 
@@ -1950,8 +1953,9 @@ packages:
     resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
     engines: {node: '>=16.0.0'}
 
-  '@zextras/carbonio-design-system@12.0.2':
-    resolution: {integrity: sha512-hKgLdG9nh8D2eeQBSXTQgMn4WwwjLy1gmnM4Z+gXK2c7XHPD6lNK37HEO1YTeSth6FPeR5Xs3fH0j6ypNyawwg==}
+  '@zextras/carbonio-design-system@12.0.4':
+    resolution: {integrity: sha512-fYKQGdk3X2kuT3qSZs7ACrnn4JBbapRoDy+bavi5VewiKASJHk2HVBjK2DOdfGSIWgnuxPofmsGcJ5xmvCZdkg==}
+    engines: {node: v22, pnpm: '>=10'}
     peerDependencies:
       '@emotion/react': ^11.14.0
       '@emotion/styled': ^11.14.0
@@ -2430,8 +2434,8 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  core-js@3.49.0:
-    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+  core-js@3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2494,8 +2498,8 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
-  darkreader@4.9.125:
-    resolution: {integrity: sha512-ImuQiS+KP0HAvW8GllH+Yy3UYZYfdS/nHM/8MVh7/14g+GoJzm/Cq6dYsRpo+cLW68udXDMtoaHrsOrbBFEh9Q==}
+  darkreader@4.9.117:
+    resolution: {integrity: sha512-owxRPqEsL/jsV6YHbGjpy+pGy+AeOSHguHk3QUAXdgVFJH//vlX3uFxvPqW7btwS+VdIdrV2DaH9DCKgSYROWA==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3208,8 +3212,8 @@ packages:
       ws:
         optional: true
 
-  graphql@16.10.0:
-    resolution: {integrity: sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==}
+  graphql@16.14.1:
+    resolution: {integrity: sha512-cQOsSMS/IrDz82PVyRDvf/Q1F/bRbBVjJlh+xYOkI1qw2bWRvWGiWc+m2O0d6l4Bt1fyY+8kzJ8JFWGJqNeDBg==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   handlebars@4.7.9:
@@ -3315,16 +3319,16 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next-browser-languagedetector@8.2.0:
-    resolution: {integrity: sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==}
+  i18next-browser-languagedetector@8.2.1:
+    resolution: {integrity: sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==}
 
-  i18next-http-backend@3.0.5:
-    resolution: {integrity: sha512-QaWHnsxieEDcqKe+vo/RFqpiIFRi/KBqlOSPcUlvinBaISCeiTRCbtrazHAjtHtsLC66oDsROAH8frWkQzfMMQ==}
+  i18next-http-backend@3.0.6:
+    resolution: {integrity: sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==}
 
-  i18next@25.6.0:
-    resolution: {integrity: sha512-tTn8fLrwBYtnclpL5aPXK/tAYBLWVvoHM1zdfXoRNLcI+RvtMsoZRV98ePlaW3khHYKuNh/Q65W/+NVFUeIwVw==}
+  i18next@25.10.10:
+    resolution: {integrity: sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==}
     peerDependencies:
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4407,25 +4411,25 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-datepicker@7.6.0:
-    resolution: {integrity: sha512-9cQH6Z/qa4LrGhzdc3XoHbhrxNcMi9MKjZmYgF/1MNNaJwvdSjv3Xd+jjvrEEbKEf71ZgCA3n7fQbdwd70qCRw==}
+  react-datepicker@7.5.0:
+    resolution: {integrity: sha512-6MzeamV8cWSOcduwePHfGqY40acuGlS1cG//ePHT6bVbLxWyqngaStenfH03n1wbzOibFggF66kWaBTb1SbTtQ==}
     peerDependencies:
-      react: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react: ^16.9.0 || ^17 || ^18
+      react-dom: ^16.9.0 || ^17 || ^18
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
 
-  react-i18next@16.0.0:
-    resolution: {integrity: sha512-JQ+dFfLnFSKJQt7W01lJHWRC0SX7eDPobI+MSTJ3/gP39xH2g33AuTE7iddAfXYHamJdAeMGM0VFboPaD3G68Q==}
+  react-i18next@16.6.6:
+    resolution: {integrity: sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==}
     peerDependencies:
-      i18next: '>= 25.5.2'
+      i18next: '>= 25.10.9'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5
+      typescript: ^5 || ^6
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -5149,6 +5153,11 @@ packages:
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5429,10 +5438,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@ardatan/relay-compiler@13.0.1(graphql@16.10.0)':
+  '@ardatan/relay-compiler@13.0.1(graphql@16.14.1)':
     dependencies:
       '@babel/runtime': 7.29.7
-      graphql: 16.10.0
+      graphql: 16.14.1
       immutable: 5.1.6
       invariant: 2.2.4
 
@@ -5965,6 +5974,11 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/dom@1.6.12':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
@@ -5976,7 +5990,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react@0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.11
@@ -5986,38 +6000,38 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@graphql-codegen/add@6.0.1(graphql@16.10.0)':
+  '@graphql-codegen/add@6.0.1(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/cli@6.3.1(@types/node@25.9.1)(graphql@16.10.0)(typescript@5.8.2)':
+  '@graphql-codegen/cli@6.3.1(@types/node@25.9.1)(graphql@16.14.1)(typescript@5.8.2)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      '@graphql-codegen/client-preset': 5.3.0(graphql@16.10.0)
-      '@graphql-codegen/core': 5.0.2(graphql@16.10.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/apollo-engine-loader': 8.0.30(graphql@16.10.0)
-      '@graphql-tools/code-file-loader': 8.1.32(graphql@16.10.0)
-      '@graphql-tools/git-loader': 8.0.36(graphql@16.10.0)
-      '@graphql-tools/github-loader': 9.1.2(@types/node@25.9.1)(graphql@16.10.0)
-      '@graphql-tools/graphql-file-loader': 8.1.14(graphql@16.10.0)
-      '@graphql-tools/json-file-loader': 8.0.28(graphql@16.10.0)
-      '@graphql-tools/load': 8.1.10(graphql@16.10.0)
-      '@graphql-tools/merge': 9.1.9(graphql@16.10.0)
-      '@graphql-tools/url-loader': 9.1.2(@types/node@25.9.1)(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-codegen/client-preset': 5.3.0(graphql@16.14.1)
+      '@graphql-codegen/core': 5.0.2(graphql@16.14.1)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/apollo-engine-loader': 8.0.30(graphql@16.14.1)
+      '@graphql-tools/code-file-loader': 8.1.32(graphql@16.14.1)
+      '@graphql-tools/git-loader': 8.0.36(graphql@16.14.1)
+      '@graphql-tools/github-loader': 9.1.2(@types/node@25.9.1)(graphql@16.14.1)
+      '@graphql-tools/graphql-file-loader': 8.1.14(graphql@16.14.1)
+      '@graphql-tools/json-file-loader': 8.0.28(graphql@16.14.1)
+      '@graphql-tools/load': 8.1.10(graphql@16.14.1)
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.1)
+      '@graphql-tools/url-loader': 9.1.2(@types/node@25.9.1)(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@inquirer/prompts': 7.10.1(@types/node@25.9.1)
       '@whatwg-node/fetch': 0.10.13
       chalk: 4.1.2
       cosmiconfig: 9.0.1(typescript@5.8.2)
       debounce: 2.2.0
       detect-indent: 6.1.0
-      graphql: 16.10.0
-      graphql-config: 5.1.6(@types/node@25.9.1)(graphql@16.10.0)(typescript@5.8.2)
+      graphql: 16.14.1
+      graphql-config: 5.1.6(@types/node@25.9.1)(graphql@16.14.1)(typescript@5.8.2)
       is-glob: 4.0.3
       jiti: 2.7.0
       json-to-pretty-yaml: 1.2.2
@@ -6041,108 +6055,108 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@graphql-codegen/client-preset@5.3.0(graphql@16.10.0)':
+  '@graphql-codegen/client-preset@5.3.0(graphql@16.14.1)':
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
-      '@graphql-codegen/add': 6.0.1(graphql@16.10.0)
-      '@graphql-codegen/gql-tag-operations': 5.2.0(graphql@16.10.0)
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-codegen/typed-document-node': 6.1.8(graphql@16.10.0)
-      '@graphql-codegen/typescript': 5.0.10(graphql@16.10.0)
-      '@graphql-codegen/typescript-operations': 5.1.0(graphql@16.10.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/documents': 1.0.1(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-codegen/add': 6.0.1(graphql@16.14.1)
+      '@graphql-codegen/gql-tag-operations': 5.2.0(graphql@16.14.1)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-codegen/typed-document-node': 6.1.8(graphql@16.14.1)
+      '@graphql-codegen/typescript': 5.0.10(graphql@16.14.1)
+      '@graphql-codegen/typescript-operations': 5.1.0(graphql@16.14.1)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/documents': 1.0.1(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/core@5.0.2(graphql@16.10.0)':
+  '@graphql-codegen/core@5.0.2(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/gql-tag-operations@5.2.0(graphql@16.10.0)':
+  '@graphql-codegen/gql-tag-operations@5.2.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       auto-bind: 4.0.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/plugin-helpers@6.3.0(graphql@16.10.0)':
+  '@graphql-codegen/plugin-helpers@6.3.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       change-case-all: 1.0.15
       common-tags: 1.8.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       import-from: 4.0.0
       tslib: 2.8.1
 
-  '@graphql-codegen/schema-ast@5.0.2(graphql@16.10.0)':
+  '@graphql-codegen/schema-ast@5.0.2(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/typed-document-node@6.1.8(graphql@16.10.0)':
+  '@graphql-codegen/typed-document-node@6.1.8(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.10.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.1)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript-operations@5.1.0(graphql@16.10.0)':
+  '@graphql-codegen/typescript-operations@5.1.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-codegen/typescript': 5.0.10(graphql@16.10.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.10.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-codegen/typescript': 5.0.10(graphql@16.14.1)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.1)
       auto-bind: 4.0.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/typescript@5.0.10(graphql@16.10.0)':
+  '@graphql-codegen/typescript@5.0.10(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-codegen/schema-ast': 5.0.2(graphql@16.10.0)
-      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.10.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-codegen/schema-ast': 5.0.2(graphql@16.14.1)
+      '@graphql-codegen/visitor-plugin-common': 6.3.0(graphql@16.14.1)
       auto-bind: 4.0.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-codegen/visitor-plugin-common@6.3.0(graphql@16.10.0)':
+  '@graphql-codegen/visitor-plugin-common@6.3.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.10.0)
-      '@graphql-tools/optimize': 2.0.0(graphql@16.10.0)
-      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-codegen/plugin-helpers': 6.3.0(graphql@16.14.1)
+      '@graphql-tools/optimize': 2.0.0(graphql@16.14.1)
+      '@graphql-tools/relay-operation-optimizer': 7.1.4(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       auto-bind: 4.0.0
       change-case-all: 1.0.15
       dependency-graph: 1.0.0
-      graphql: 16.10.0
-      graphql-tag: 2.12.6(graphql@16.10.0)
+      graphql: 16.14.1
+      graphql-tag: 2.12.6(graphql@16.14.1)
       parse-filepath: 1.0.2
       tslib: 2.8.1
 
-  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@25.9.1)(eslint@8.57.1)(graphql@16.10.0)(typescript@5.8.2)':
+  '@graphql-eslint/eslint-plugin@4.3.0(@types/node@25.9.1)(eslint@8.57.1)(graphql@16.14.1)(typescript@5.8.2)':
     dependencies:
-      '@graphql-tools/code-file-loader': 8.1.32(graphql@16.10.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.10.0)
-      '@graphql-tools/utils': 10.11.0(graphql@16.10.0)
+      '@graphql-tools/code-file-loader': 8.1.32(graphql@16.14.1)
+      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.14.1)
+      '@graphql-tools/utils': 10.11.0(graphql@16.14.1)
       debug: 4.4.3
       eslint: 8.57.1
       fast-glob: 3.3.3
-      graphql: 16.10.0
-      graphql-config: 5.1.6(@types/node@25.9.1)(graphql@16.10.0)(typescript@5.8.2)
-      graphql-depth-limit: 1.1.0(graphql@16.10.0)
+      graphql: 16.14.1
+      graphql-config: 5.1.6(@types/node@25.9.1)(graphql@16.14.1)(typescript@5.8.2)
+      graphql-depth-limit: 1.1.0(graphql@16.14.1)
       lodash.lowercase: 4.3.0
     transitivePeerDependencies:
       - '@fastify/websocket'
@@ -6156,64 +6170,64 @@ snapshots:
 
   '@graphql-hive/signal@2.0.0': {}
 
-  '@graphql-tools/apollo-engine-loader@8.0.30(graphql@16.10.0)':
+  '@graphql-tools/apollo-engine-loader@8.0.30(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@whatwg-node/fetch': 0.10.13
-      graphql: 16.10.0
+      graphql: 16.14.1
       sync-fetch: 0.6.0
       tslib: 2.8.1
 
-  '@graphql-tools/batch-execute@10.0.8(graphql@16.10.0)':
+  '@graphql-tools/batch-execute@10.0.8(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/code-file-loader@8.1.32(graphql@16.10.0)':
+  '@graphql-tools/code-file-loader@8.1.32(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       globby: 11.1.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
       unixify: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/delegate@12.0.16(graphql@16.10.0)':
+  '@graphql-tools/delegate@12.0.16(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/batch-execute': 10.0.8(graphql@16.10.0)
-      '@graphql-tools/executor': 1.5.3(graphql@16.10.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/batch-execute': 10.0.8(graphql@16.14.1)
+      '@graphql-tools/executor': 1.5.3(graphql@16.14.1)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/promise-helpers': 1.3.2
       dataloader: 2.2.3
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/documents@1.0.1(graphql@16.10.0)':
+  '@graphql-tools/documents@1.0.1(graphql@16.14.1)':
     dependencies:
-      graphql: 16.10.0
+      graphql: 16.14.1
       lodash.sortby: 4.7.0
       tslib: 2.8.1
 
-  '@graphql-tools/executor-common@1.0.6(graphql@16.10.0)':
+  '@graphql-tools/executor-common@1.0.6(graphql@16.14.1)':
     dependencies:
       '@envelop/core': 5.5.1
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
 
-  '@graphql-tools/executor-graphql-ws@3.1.5(graphql@16.10.0)':
+  '@graphql-tools/executor-graphql-ws@3.1.5(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/executor-common': 1.0.6(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@whatwg-node/disposablestack': 0.0.6
-      graphql: 16.10.0
-      graphql-ws: 6.0.8(graphql@16.10.0)(ws@8.21.0)
+      graphql: 16.14.1
+      graphql-ws: 6.0.8(graphql@16.14.1)(ws@8.21.0)
       isows: 1.0.7(ws@8.21.0)
       tslib: 2.8.1
       ws: 8.21.0
@@ -6223,26 +6237,26 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/executor-http@3.3.0(@types/node@25.9.1)(graphql@16.10.0)':
+  '@graphql-tools/executor-http@3.3.0(@types/node@25.9.1)(graphql@16.14.1)':
     dependencies:
       '@graphql-hive/signal': 2.0.0
-      '@graphql-tools/executor-common': 1.0.6(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/executor-common': 1.0.6(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       meros: 1.3.2(@types/node@25.9.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-legacy-ws@1.1.28(graphql@16.10.0)':
+  '@graphql-tools/executor-legacy-ws@1.1.28(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@types/ws': 8.18.1
-      graphql: 16.10.0
+      graphql: 16.14.1
       isomorphic-ws: 5.0.0(ws@8.21.0)
       tslib: 2.8.1
       ws: 8.21.0
@@ -6250,21 +6264,21 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@graphql-tools/executor@1.5.3(graphql@16.10.0)':
+  '@graphql-tools/executor@1.5.3(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/disposablestack': 0.0.6
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/git-loader@8.0.36(graphql@16.10.0)':
+  '@graphql-tools/git-loader@8.0.36(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       is-glob: 4.0.3
       micromatch: 4.0.8
       tslib: 2.8.1
@@ -6272,101 +6286,101 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/github-loader@9.1.2(@types/node@25.9.1)(graphql@16.10.0)':
+  '@graphql-tools/github-loader@9.1.2(@types/node@25.9.1)(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/executor-http': 3.3.0(@types/node@25.9.1)(graphql@16.10.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/executor-http': 3.3.0(@types/node@25.9.1)(graphql@16.14.1)
+      '@graphql-tools/graphql-tag-pluck': 8.3.31(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       sync-fetch: 0.6.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
 
-  '@graphql-tools/graphql-file-loader@8.1.14(graphql@16.10.0)':
+  '@graphql-tools/graphql-file-loader@8.1.14(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/import': 7.1.14(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/import': 7.1.14(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       globby: 11.1.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/graphql-tag-pluck@8.3.31(graphql@16.10.0)':
+  '@graphql-tools/graphql-tag-pluck@8.3.31(graphql@16.14.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
-  '@graphql-tools/import@7.1.14(graphql@16.10.0)':
+  '@graphql-tools/import@7.1.14(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       resolve-from: 5.0.0
       tslib: 2.8.1
 
-  '@graphql-tools/json-file-loader@8.0.28(graphql@16.10.0)':
+  '@graphql-tools/json-file-loader@8.0.28(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       globby: 11.1.0
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
       unixify: 1.0.0
 
-  '@graphql-tools/load@8.1.10(graphql@16.10.0)':
+  '@graphql-tools/load@8.1.10(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/schema': 10.0.33(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       p-limit: 3.1.0
       tslib: 2.8.1
 
-  '@graphql-tools/merge@9.1.9(graphql@16.10.0)':
+  '@graphql-tools/merge@9.1.9(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/optimize@2.0.0(graphql@16.10.0)':
+  '@graphql-tools/optimize@2.0.0(graphql@16.14.1)':
     dependencies:
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/relay-operation-optimizer@7.1.4(graphql@16.10.0)':
+  '@graphql-tools/relay-operation-optimizer@7.1.4(graphql@16.14.1)':
     dependencies:
-      '@ardatan/relay-compiler': 13.0.1(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@ardatan/relay-compiler': 13.0.1(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/schema@10.0.33(graphql@16.10.0)':
+  '@graphql-tools/schema@10.0.33(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/merge': 9.1.9(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      graphql: 16.10.0
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/url-loader@9.1.2(@types/node@25.9.1)(graphql@16.10.0)':
+  '@graphql-tools/url-loader@9.1.2(@types/node@25.9.1)(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/executor-graphql-ws': 3.1.5(graphql@16.10.0)
-      '@graphql-tools/executor-http': 3.3.0(@types/node@25.9.1)(graphql@16.10.0)
-      '@graphql-tools/executor-legacy-ws': 1.1.28(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
-      '@graphql-tools/wrap': 11.1.15(graphql@16.10.0)
+      '@graphql-tools/executor-graphql-ws': 3.1.5(graphql@16.14.1)
+      '@graphql-tools/executor-http': 3.3.0(@types/node@25.9.1)(graphql@16.14.1)
+      '@graphql-tools/executor-legacy-ws': 1.1.28(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
+      '@graphql-tools/wrap': 11.1.15(graphql@16.14.1)
       '@types/ws': 8.18.1
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       isomorphic-ws: 5.0.0(ws@8.21.0)
       sync-fetch: 0.6.0
       tslib: 2.8.1
@@ -6378,34 +6392,34 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/utils@10.11.0(graphql@16.10.0)':
+  '@graphql-tools/utils@10.11.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.1)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/utils@11.1.0(graphql@16.10.0)':
+  '@graphql-tools/utils@11.1.0(graphql@16.14.1)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.1)
       '@whatwg-node/promise-helpers': 1.3.2
       cross-inspect: 1.0.1
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-tools/wrap@11.1.15(graphql@16.10.0)':
+  '@graphql-tools/wrap@11.1.15(graphql@16.14.1)':
     dependencies:
-      '@graphql-tools/delegate': 12.0.16(graphql@16.10.0)
-      '@graphql-tools/schema': 10.0.33(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/delegate': 12.0.16(graphql@16.14.1)
+      '@graphql-tools/schema': 10.0.33(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       '@whatwg-node/promise-helpers': 1.3.2
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  '@graphql-typed-document-node/core@3.2.0(graphql@16.10.0)':
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.1)':
     dependencies:
-      graphql: 16.10.0
+      graphql: 16.14.1
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -6747,7 +6761,7 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
+  '@rollup/rollup-linux-x64-gnu@4.53.3':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
@@ -6771,7 +6785,7 @@ snapshots:
   '@rollup/rollup-win32-x64-gnu@4.60.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
+  '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.4':
@@ -7376,18 +7390,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@zextras/carbonio-design-system@12.0.2(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(date-fns@3.6.0)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@zextras/carbonio-design-system@12.0.4(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(date-fns@3.6.0)(lodash@4.18.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@floating-ui/dom': 1.7.6
-      core-js: 3.49.0
-      darkreader: 4.9.125
+      '@floating-ui/dom': 1.6.12
+      core-js: 3.39.0
+      darkreader: 4.9.117
       date-fns: 3.6.0
       lodash: 4.18.1
       polished: 4.3.1
       react: 18.3.1
-      react-datepicker: 7.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-datepicker: 7.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-dom: 18.3.1(react@18.3.1)
 
   '@zextras/carbonio-ui-configs@2.1.0(@testing-library/dom@10.4.1)(typescript@5.8.2)':
@@ -7920,7 +7934,7 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  core-js@3.49.0: {}
+  core-js@3.39.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -7988,12 +8002,12 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
-  darkreader@4.9.125:
+  darkreader@4.9.117:
     dependencies:
       malevic: 0.20.2
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.53.3
+      '@rollup/rollup-win32-x64-msvc': 4.53.3
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -8830,16 +8844,16 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@5.1.6(@types/node@25.9.1)(graphql@16.10.0)(typescript@5.8.2):
+  graphql-config@5.1.6(@types/node@25.9.1)(graphql@16.14.1)(typescript@5.8.2):
     dependencies:
-      '@graphql-tools/graphql-file-loader': 8.1.14(graphql@16.10.0)
-      '@graphql-tools/json-file-loader': 8.0.28(graphql@16.10.0)
-      '@graphql-tools/load': 8.1.10(graphql@16.10.0)
-      '@graphql-tools/merge': 9.1.9(graphql@16.10.0)
-      '@graphql-tools/url-loader': 9.1.2(@types/node@25.9.1)(graphql@16.10.0)
-      '@graphql-tools/utils': 11.1.0(graphql@16.10.0)
+      '@graphql-tools/graphql-file-loader': 8.1.14(graphql@16.14.1)
+      '@graphql-tools/json-file-loader': 8.0.28(graphql@16.14.1)
+      '@graphql-tools/load': 8.1.10(graphql@16.14.1)
+      '@graphql-tools/merge': 9.1.9(graphql@16.14.1)
+      '@graphql-tools/url-loader': 9.1.2(@types/node@25.9.1)(graphql@16.14.1)
+      '@graphql-tools/utils': 11.1.0(graphql@16.14.1)
       cosmiconfig: 8.3.6(typescript@5.8.2)
-      graphql: 16.10.0
+      graphql: 16.14.1
       jiti: 2.7.0
       minimatch: 10.2.5
       string-env-interpolation: 1.0.1
@@ -8852,23 +8866,23 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-depth-limit@1.1.0(graphql@16.10.0):
+  graphql-depth-limit@1.1.0(graphql@16.14.1):
     dependencies:
       arrify: 1.0.1
-      graphql: 16.10.0
+      graphql: 16.14.1
 
-  graphql-tag@2.12.6(graphql@16.10.0):
+  graphql-tag@2.12.6(graphql@16.14.1):
     dependencies:
-      graphql: 16.10.0
+      graphql: 16.14.1
       tslib: 2.8.1
 
-  graphql-ws@6.0.8(graphql@16.10.0)(ws@8.21.0):
+  graphql-ws@6.0.8(graphql@16.14.1)(ws@8.21.0):
     dependencies:
-      graphql: 16.10.0
+      graphql: 16.14.1
     optionalDependencies:
       ws: 8.21.0
 
-  graphql@16.10.0: {}
+  graphql@16.14.1: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -8966,17 +8980,17 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next-browser-languagedetector@8.2.0:
+  i18next-browser-languagedetector@8.2.1:
     dependencies:
       '@babel/runtime': 7.29.7
 
-  i18next-http-backend@3.0.5:
+  i18next-http-backend@3.0.6:
     dependencies:
       cross-fetch: 4.1.0
     transitivePeerDependencies:
       - encoding
 
-  i18next@25.6.0(typescript@5.8.2):
+  i18next@25.10.10(typescript@5.8.2):
     dependencies:
       '@babel/runtime': 7.29.7
     optionalDependencies:
@@ -9562,7 +9576,7 @@ snapshots:
       '@open-draft/deferred-promise': 2.2.0
       '@types/cookie': 0.6.0
       '@types/statuses': 2.0.6
-      graphql: 16.10.0
+      graphql: 16.14.1
       headers-polyfill: 4.0.3
       is-node-process: 1.2.0
       outvariant: 1.4.3
@@ -9962,11 +9976,12 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-datepicker@7.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-datepicker@7.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@floating-ui/react': 0.27.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       date-fns: 3.6.0
+      prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -9976,12 +9991,13 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-i18next@16.0.0(i18next@25.6.0(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2):
+  react-i18next@16.6.6(i18next@25.10.10(typescript@5.8.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2):
     dependencies:
       '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
-      i18next: 25.6.0(typescript@5.8.2)
+      i18next: 25.10.10(typescript@5.8.2)
       react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.8.2
@@ -10830,6 +10846,10 @@ snapshots:
   url-join@5.0.0: {}
 
   urlpattern-polyfill@10.1.0: {}
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Weekly dependencies update — 2026-06-04

Automated bundle of all **runtime dependencies** bumped to the latest minor/patch within the same major.

### Updates

| Package | Old | New | Minor jump | Peer | Security |
|---|---|---|---|---|---|
| `@zextras/carbonio-design-system` | `12.0.2` | `12.0.4` | 0 |  |  |
| `graphql` | `16.10.0` | `16.14.1` | +4 |  |  |
| `i18next` | `25.6.0` | `25.10.10` | +4 |  |  |
| `i18next-browser-languagedetector` | `8.2.0` | `8.2.1` | 0 |  |  |
| `i18next-http-backend` | `3.0.5` | `3.0.6` | 0 |  |  |
| `react-i18next` | `16.0.0` | `16.6.6` | +6 |  |  |

### ⚠️ High-risk updates

> Runtime dependencies with a minor version jump ≥ 3 — check the release notes below carefully.

| Package | Old | New | Minor jump |
|---|---|---|---|
| `graphql` | `16.10.0` | `16.14.1` | +4 |
| `i18next` | `25.6.0` | `25.10.10` | +4 |
| `react-i18next` | `16.0.0` | `16.6.6` | +6 |

### Notes

- Base branch: `devel`
- Command: `ncu -u --target minor --filter "@zextras/carbonio-design-system graphql i18next i18next-browser-languagedetector i18next-http-backend react-i18next" && pnpm install`
- Only `package.json` and `pnpm-lock.yaml` were modified.

🤖 Generated by the `update-deps` skill.

### Changelogs

#### `@zextras/carbonio-design-system` 12.0.2 → 12.0.4

#### [`v12.0.3`](https://github.com/zextras/carbonio-design-system/releases/tag/v12.0.3)

## [12.0.3](https://github.com/zextras/carbonio-design-system/compare/v12.0.2...v12.0.3) (2026-04-29)

### Other changes

* migrate from npm to pnpm ([f9fd559](https://github.com/zextras/carbonio-design-system/commit/f9fd55947056579c35489f65845f89b50e774084)), closes [#629](https://github.com/zextras/carbonio-design-system/issues/629)

---

#### [`v12.0.4`](https://github.com/zextras/carbonio-design-system/releases/tag/v12.0.4)

## [12.0.4](https://github.com/zextras/carbonio-design-system/compare/v12.0.3...v12.0.4) (2026-05-05)

### Bug Fixes

---

#### `graphql` 16.10.0 → 16.14.1

#### [`v16.11.0`](https://github.com/graphql/graphql-js/releases/tag/v16.11.0) — 16.11.0

## v16.11.0 (2025-04-26)

#### New Feature 🚀
* [#4363](https://github.com/graphql/graphql-js/pull/4363) Ensure we validate for using nullable variables in oneOf input fields ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4366](https://github.com/graphql/graphql-js/pull/4366) feat(execution): add max coercion errors option to execution context ([@cristunaranjo](https://github.com/cristunaranjo))

#### Bug Fix 🐞
* [#4367](https://github.com/graphql/graphql-js/pull/4367) fix(coerce-input-value): input object coercion rejects arrays ([@cristunaranjo](https://github.com/cristunaranjo))

#### Docs 📝
<details>
<summary> 11 PRs were merged </summary>

* [#4310](https://github.com/graphql/graphql-js/pull/4310) First draft for upgrade guide to v17 ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4331](https://github.com/graphql/graphql-js/pull/4331) fix sidebar for documentation and `/api-v16` ([@dimaMachina](https://github.com/dimaMachina))
* [#4335](https://github.com/graphql/graphql-js/pull/4335) Add cspell exception ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4340](https://github.com/graphql/graphql-js/pull/4340) Improve flow of documentation around GraphiQL ([@benjie](https://github.com/benjie))
* [#4343](https://github.com/graphql/graphql-js/pull/4343) typofix: removes extra parenthesis from getting started code snippet ([@rabahalishah](https://github.com/rabahalishah))
* [#4351](https://github.com/graphql/graphql-js/pull/4351) fixed wrong variable name ([@fto-dev](https://github.com/fto-dev))
* [#4352](https://github.com/graphql/graphql-js/pull/4352) docs(getting-started): promises current links ([@guspan-tanadi](https://github.com/guspan-tanadi))
* [#4368](https://github.com/graphql/graphql-js/pull/4368) Update docs for execution options ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4369](https://github.com/graphql/graphql-js/pull/4369) Correct some syntax ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4372](https://github.com/graphql/graphql-js/pull/4372) Refactor every code-first example to leverage resolve ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4373](https://github.com/graphql/graphql-js/pull/4373) docs: Update getting-started.mdx ([@Shubhdeep12](https://github.com/Shubhdeep12))
</details>

#### Polish 💅
* [#4312](https://github.com/graphql/graphql-js/pull/4312) Increase print/visit performance ([@JoviDeCroock](https://github.com/JoviDeCroock))

#### Internal 🏠
<summary> 4 PRs were merged </summary>

* [#4327](https://github.com/graphql/graphql-js/pull/4327) Add redirect for /api ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4377](https://github.com/graphql/graphql-js/pull/4377) Chore: bump setup-node ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4378](https://github.com/graphql/graphql-js/pull/4378) Change to gqlConf 2025 ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4379](https://github.com/graphql/graphql-js/pull/4379) Add missing parenthesis ([@benjie](https://github.com/benjie))

#### Committers: 8
* Benjie([@benjie](https://github.com/benjie))
* Cris Naranjo ([@cristunaranjo](https://github.com/cristunaranjo))
* Dimitri POSTOLOV([@dimaMachina](https://github.com/dimaMachina))
* Fatih Ozdemir([@fto-dev](https://github.com/fto-dev))
* Guspan Tanadi([@guspan-tanadi](https://github.com/guspan-tanadi))
* Jovi De Croock([@JoviDeCroock](https://github.com/JoviDeCroock))
* Rabah Ali Shah([@rabahalishah](https://github.com/rabahalishah))
* Shubhdeep Chhabra([@Shubhdeep12](https://github.com/Shubhdeep12))

---

#### [`v16.12.0`](https://github.com/graphql/graphql-js/releases/tag/v16.12.0) — 16.12.0

## v16.12.0 (2025-11-01)

#### New Feature 🚀
* [#4482](https://github.com/graphql/graphql-js/pull/4482) Implement changes for executable descriptions ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4493](https://github.com/graphql/graphql-js/pull/4493) Backport schema coordinates ([@JoviDeCroock](https://github.com/JoviDeCroock))

#### Bug Fix 🐞
* [#4392](https://github.com/graphql/graphql-js/pull/4392) Catch unhandled exception in abstract resolution ([@JoviDeCroock](https://github.com/JoviDeCroock))

#### Docs 📝
<details>
<summary> 28 PRs were merged </summary>

* [#4374](https://github.com/graphql/graphql-js/pull/4374) docs: testing graphQL servers ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4376](https://github.com/graphql/graphql-js/pull/4376) docs: type generation for graphql servers ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4380](https://github.com/graphql/graphql-js/pull/4380) docs: add guides for custom scalars ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4381](https://github.com/graphql/graphql-js/pull/4381) docs: anatomy of a resolver ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4382](https://github.com/graphql/graphql-js/pull/4382) docs: understanding graphql errors ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4383](https://github.com/graphql/graphql-js/pull/4383) docs: N+1 problem and DataLoader ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4391](https://github.com/graphql/graphql-js/pull/4391) docs: cursor-based pagination guide ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4393](https://github.com/graphql/graphql-js/pull/4393) docs: add page on abstract types ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4394](https://github.com/graphql/graphql-js/pull/4394) docs: editorial on abstract types page ([@benjie](https://github.com/benjie))
* [#4395](https://github.com/graphql/graphql-js/pull/4395) docs: editorial for recent documentation updates ([@benjie](https://github.com/benjie))
* [#4396](https://github.com/graphql/graphql-js/pull/4396) docs: add page on authorization strategies ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4398](https://github.com/graphql/graphql-js/pull/4398) docs: update "going to production" guide ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4399](https://github.com/graphql/graphql-js/pull/4399) Update mutations-and-input-types.mdx ([@roman-lakhnov](https://github.com/roman-lakhnov))
* [#4400](https://github.com/graphql/graphql-js/pull/4400) Remove CJS from docs ([@JoviDeCroock](https://github.com/JoviDeCroock))
* [#4401](https://github.com/graphql/graphql-js/pull/4401) docs: add guide on directives ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4402](https://github.com/graphql/graphql-js/pull/4402) docs: add guide for operation complexity controls ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4405](https://github.com/graphql/graphql-js/pull/4405) docs: add guide on nullability ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4406](https://github.com/graphql/graphql-js/pull/4406) docs: add guide on subscriptions ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4411](https://github.com/graphql/graphql-js/pull/4411) docs: add guide on caching strategies ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4414](https://github.com/graphql/graphql-js/pull/4414) docs: guide on scaling your API ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4416](https://github.com/graphql/graphql-js/pull/4416) Editorial for #4405 (nullability) ([@benjie](https://github.com/benjie))
* [#4417](https://github.com/graphql/graphql-js/pull/4417) Indicate that field arguments should always be preferred over directives ([@benjie](https://github.com/benjie))
* [#4418](https://github.com/graphql/graphql-js/pull/4418) docs: trusted documents ([@benjie](https://github.com/benjie))
* [#4419](https://github.com/graphql/graphql-js/pull/4419) docs: cleanup and fixes ([@sarahxsanders](https://github.com/sarahxsanders))
* [#4436](https://github.com/graphql/graphql-js/pull/4436) Suggestions for federation links ([@Urigo](https://github.com/Urigo))
* [#4444](https://github.com/graphql/graphql-js/pull/4444) Fix navig

> _…changelog trimmed._

---

#### `i18next` 25.6.0 → 25.10.10

#### [`v25.6.1`](https://github.com/i18next/i18next/releases/tag/v25.6.1)

- fix: createInstance does not exist on an instance [#2366](https://github.com/i18next/i18next/issues/2366)

---

#### [`v25.6.2`](https://github.com/i18next/i18next/releases/tag/v25.6.2)

- types: export `InterpolationMap`

---

#### [`v25.6.3`](https://github.com/i18next/i18next/releases/tag/v25.6.3)

- chore: dependency updates [2368](https://github.com/i18next/i18next/issues/2366)

---

#### [`v25.7.0`](https://github.com/i18next/i18next/releases/tag/v25.7.0)

- Enhance `cloneInstance` to create a new interpolator if interpolation options are passed in. This will address [2371](https://github.com/i18next/i18next/issues/2371).

---

#### [`v25.7.1`](https://github.com/i18next/i18next/releases/tag/v25.7.1)

- TS: remove wrong signature [2372](https://github.com/i18next/i18next/issues/2372).

---

#### [`v25.7.2`](https://github.com/i18next/i18next/releases/tag/v25.7.2)

- fix: Invalid overwrite of default value for overloadTranslationOptionHandler [2374](https://github.com/i18next/i18next/issues/2374).

---

#### [`v25.7.3`](https://github.com/i18next/i18next/releases/tag/v25.7.3)

- type definitions for new transDefaultProps option in react-i18next [react-i18next: #1895](https://github.com/i18next/react-i18next/issues/1895)

---

#### [`v25.7.4`](https://github.com/i18next/i18next/releases/tag/v25.7.4)

- fix: Interpolation breaks when cloning an instance [2376](https://github.com/i18next/react-i18next/issues/2376)

---

#### [`v25.8.0`](https://github.com/i18next/i18next/releases/tag/v25.8.0)

- fix: TFunctionReturn fallback [2360](https://github.com/i18next/i18next/issues/2360)

---

#### [`v25.8.1`](https://github.com/i18next/i18next/releases/tag/v25.8.1)

- fix(types): Selector API - fix Namespace inference for selector ns option [2384](https://github.com/i18next/i18next/pull/2384)

---

#### [`v25.8.2`](https://github.com/i18next/i18next/releases/tag/v25.8.2)

- option to suppress the support message [2385](https://github.com/i18next/i18next/issues/2385)

---

#### [`v25.8.3`](https://github.com/i18next/i18next/releases/tag/v25.8.3)

- ts: document option to suppress the support message [2385](https://github.com/i18next/i18next/issues/2385)

---

#### [`v25.8.4`](https://github.com/i18next/i18next/releases/tag/v25.8.4)

- fix: crashes when backend in backends array has no name property [2386](https://github.com/i18next/i18next/issues/2386)

---

#### [`v25.8.5`](https://github.com/i18next/i18next/releases/tag/v25.8.5)

- fix: compatibility with moduleResolution bundler (issue [2380](https://github.com/i18next/i18next/issues/2380)) [2381](https://github.com/i18next/i18next/pull/2381)

---

#### [`v25.8.6`](https://github.com/i18next/i18next/releases/tag/v25.8.6)

- ts: address incomplete type definition for `getFixedT()` return value [2318](https://github.com/i18next/i18next/issues/2318)

---

#### [`v25.8.7`](https://github.com/i18next/i18next/releases/tag/v25.8.7)

- avoid crash due to ReferenceError without Intl API [2391](https://github.com/i18next/i18next/pull/2391)

---

#### [`v25.8.8`](https://github.com/i18next/i18next/releases/tag/v25.8.8)

- types(i18n): add missing toJSON() declaration [2393](https://github.com/i18next/i18next/pull/2393)

---

#### [`v25.8.9`](https://github.com/i18next/i18next/releases/tag/v25.8.9)

- fix(interpolator): escape nestingOptionsSeparator in nesting option parsing [223943](https://github.com/i18next/i18next/pull/2394)

---

#### [`v25.8.10`](https://github.com/i18next/i18next/releases/tag/v25.8.10)

- fix(interpolator): guard null matchedDoubleQuotes in nesting option parsing [2395](https://github.com/i18next/i18next/pull/2395)

---

#### [`v25.8.11`](https://github.com/i18next/i18next/releases/tag/v25.8.11)

- revert fix: compatibility with moduleResolution bundler (issue [2380](https://github.com/i18next/i18next/issues/2380)) [2381](https://github.com/i18next/i18next/pull/2381)

---

#### [`v25.8.12`](https://github.com/i18next/i18next/releases/tag/v25.8.12)

- improve support notice shown logic

---

#### [`v25.8.13`](https://github.com/i18next/i18next/releases/tag/v25.8.13)

- improve support notice shown logic

---

#### [`v25.8.14`](https://github.com/i18next/i18next/releases/tag/v25.8.14)

- fix: getCleanedCode now replaces all underscores

---

#### [`v25.8.15`](https://github.com/i18next/i18next/releases/tag/v25.8.15)

- fix: Selector API unable to resolve namespaces [#2402](https://github.com/i18next/i18next/issues/2402)

---

#### [`v25.8.16`](https://github.com/i18next/i18next/releases/tag/v25.8.16)

- fix(types): `on()` method now correctly returns `this` instead of `void`, matching the runtime behavior and enabling proper method chaining in TypeScript

---

#### [`v25.8.17`](https://github.com/i18next/i18next/releases/tag/v25.8.17)

- update deps

---

#### [`v25.8.18`](https://github.com/i18next/i18next/releases/tag/v25.8.18)

- improve selector api to accept array of selector functions, analogous to array of keys [2404](https://github.com/i18next/i18next/issues/2404)

---

#### [`v25.8.19`](https://github.com/i18next/i18next/releases/tag/v25.8.19)

- fix: selector API namespace resolution regression for single-string `ns` and primary namespace in array [#2405](https://github.com/i18next/i18next/issues/2405). Reverts the broad namespace-prefix rewrite from v25.8.15 and replaces it with a targeted fix that only rewrites paths starting with a secondary namespace in a multi-namespace array, matching the type-level contract of `GetSource`

---

#### [`v25.8.20`](https://github.com/i18next/i18next/releases/tag/v25.8.20)

- - fix: `getFixedT()` selector now resolves namespaces against the effective `ns` rather than the global init options [#2406](https://github.com/i18next/i18next/issues/2406)

---

#### [`v25.9.0`](https://github.com/i18next/i18next/releases/tag/v25.9.0)

- feat(types): selector API now enforces `{ count: number }` when a key resolves to plural forms [2373](https://github.com/i18next/i18next/issues/2373)
- fix(types): string unions with invalid members are now correctly detected as type errors when used as context option [2172](https://github.com/i18next/i18next/issues/2172)

---

#### [`v25.10.0`](https://github.com/i18next/i18next/releases/tag/v25.10.0)

- feat(types): `keyFromSelector` now returns a branded `SelectorKey` type that `t()` accepts directly, enabling pre-computed and reusable translation keys [2364](https://github.com/i18next/i18next/issues/2364)
- feat: support selector syntax for `keyPrefix` in `getFixedT` and per-call options [2367](https://github.com/i18next/i18next/issues/2367)
- feat(types): interpolation values are now automatically typed based on built-in format specifiers — `{{val, number}}` requires `number`, `{{val, datetime}}` requires `Date`, `{{name}}` requires `string`, etc. Custom formatters can be typed via `interpolationFormatTypeMap` in `CustomTypeOptions` [2378](https://github.com/i18next/i18next/issues/2378)
- fix(types): `FilterKeys` in selector mode now preserves non-context, non-plural leaf keys when `context` is provided, fixing incorrect type narrowing when combining `returnObjects: true` with `context` [2398](https://github.com/i18next/i18next/issues/2398)

---

#### [`v25.10.1`](https://github.com/i18next/i18next/releases/tag/v25.10.1)

- fix(types): `FilterKeys` now correctly excludes base keys that have context variants when the provided context doesn't match any of them (e.g. key `some` with variant `some_me` is no longer accessible with `context="one"`)

---

#### [`v25.10.2`](https://github.com/i18next/i18next/releases/tag/v25.10.2)

- feat(types): `keyFromSelector` is now type-safe — the selector callback is constrained against your resource definitions, catching invalid keys at compile time. Supports optional `ns` and `keyPrefix` options for non-default namespace/prefix contexts [2364](https://github.com/i18next/i18next/issues/2364)

---

#### [`v25.

> _…changelog trimmed._

---

#### `i18next-browser-languagedetector` 8.2.0 → 8.2.1

#### 8.2.1

- Add missing typescript definition for hash options [33154](https://github.com/i18next/i18next-browser-languageDetector/pull/315)


_Source: [CHANGELOG.md](https://github.com/i18next/i18next-browser-languageDetector/blob/HEAD/CHANGELOG.md)_

---

#### `i18next-http-backend` 3.0.5 → 3.0.6

#### 3.0.6

- fix: allow forward slashes in `ns` values so nested namespace names (mapping to URL layouts such as `/locales/en/a/b.json`) fetch correctly again. 3.0.5's security fix applied the same strict URL-segment check to both `lng` and `ns`, which was correct for `lng` (no BCP-47 shape contains `/`) but over-strict for `ns` — nested namespaces containing `/` were never officially supported, but the behaviour fell out of the implicit string-substitution semantics of `loadPath` and is common enough in the wild to be worth accommodating. `isSafeUrlSegment` is now split into `isSafeLangUrlSegment` (strict — still rejects `/`) and `isSafeNsUrlSegment` (loose — allows `/` but still rejects `..`, `\`, URL-structure characters, control chars, prototype keys, and oversized inputs). `isSafeUrlSegment` is kept as a backwards-compatible alias for the strict check. The 3.0.5 security fix remains in force for every concrete attack pattern from the original advisory.


_Source: [CHANGELOG.md](https://github.com/i18next/i18next-http-backend/blob/HEAD/CHANGELOG.md)_

---

#### `react-i18next` 16.0.0 → 16.6.6

#### 16.0.1

- fix: Using <Trans> component with named tags throws error when Selector API is enabled [1867](https://github.com/i18next/react-i18next/issues/1867) with [1868](https://github.com/i18next/react-i18next/pull/1868)

---

#### 16.1.0

- Introduce `IcuTrans` component [1869](https://github.com/i18next/react-i18next/issues/1869)

---

#### 16.1.1

- exports for `IcuTrans` component [1873](https://github.com/i18next/react-i18next/pull/1873)

---

#### 16.1.2

- missing.js extensions for Icu imports

---

#### 16.1.3

- fix: ensure invalid identifiers are quoted in the props object [1874](https://github.com/i18next/react-i18next/pull/1874)

---

#### 16.1.4

- fix: detect pre-transformation use of interpolation like number/date/etc. [1875](https://github.com/i18next/react-i18next/pull/1875)

---

#### 16.1.5

- fix: Incosistent behaviour of Trans and t. Trans set defaultValue when t call doesn't set the field. [1876](https://github.com/i18next/react-i18next/issues/1876)
- Trans: use also defaultValue via tOptions as fallback

---

#### 16.1.6

- fix: fix: handle spread props for inner components in Trans (icu) [1877](https://github.com/i18next/react-i18next/pull/1877)

---

#### 16.2.0

- try to address: useTranslation hook violates React's rules of hooks by conditionally calling inner hooks [1863](https://github.com/i18next/react-i18next/issues/1863)

---

#### 16.2.1

- fix regression in v16.2.0: bindI18nStore does not work correctly [1879](https://github.com/i18next/react-i18next/issues/1879)

---

#### 16.2.2

- fix trans component break with less than sign [1880](https://github.com/i18next/react-i18next/pull/1880), closes [1734](https://github.com/i18next/react-i18next/issues/1734)

---

#### 16.2.3

- fix hyphened component break issue [1882](https://github.com/i18next/react-i18next/pull/1882)

---

#### 16.2.4

- try to fix "Trans component do not render anymore children as default value in test environment" [1883](https://github.com/i18next/react-i18next/issues/1883) by also respecting [1876](https://github.com/i18next/react-i18next/issues/1876)

---

#### 16.3.0

- fix: add i18n wrapper for React Compiler and React.memo compatibility [1884](https://github.com/i18next/react-i18next/pull/1884)

---

#### 16.3.1

- revert fix: Incosistent behaviour of Trans and t. Trans set defaultValue when t call doesn't set the field. [1876](https://github.com/i18next/react-i18next/issues/1876) [f22d478](https://github.com/i18next/react-i18next/commit/f22d4787187e6cfc54d57f5fbede1c816ea19565)

---

#### 16.3.2

- fix: avoid "Uncaught TypeError: Cannot redefine property: \_\_original"

---

#### 16.3.3

- improve useTranslation to fix "Maximum update depth exceeded" but still support new react-compiler [1885](https://github.com/i18next/react-i18next/issues/1885) [1863](https://github.com/i18next/react-i18next/issues/1863#issuecomment-3491246391)

---

#### 16.3.4

- Fix: avoid the "ref is not a prop" warning when a user ref is placed on an element inside `<Trans>` [1887](https://github.com/i18next/react-i18next/issues/1887), by still trying to fix element.ref access issue with react 19 [1846](https://github.com/i18next/react-i18next/pull/1846)

---

#### 16.3.5

- fix runaway effect in useTranslation [1888](https://github.com/i18next/react-i18next/issues/1888) by [1889](https://github.com/i18next/react-i18next/pull/1889)

---

#### 16.4.0

- `<Trans count>` prop: optional - infer count from children [1891](https://github.com/i18next/react-i18next/issues/1891)

---

#### 16.4.1

- fix(Trans): prevent double-escaping of interpolated values in component props (e.g. title). Unescape HTML entities before passing prop values to React to avoid rendered output like `&amp;quot;` / `&amp;#39;`. [1893](https://github.com/i18next/react-i18next/issues/1893)

---

#### 16.5.0

- Add configuration option `transDefaultProps` to set default props for the Trans component (e.g. `tOptions`, `shouldUnescape`, `values`) [1895](https://github.com/i18next/react-i18next/issues/1895)

---

#### 16.5.1

- fix: export `nodesToString` (runtime + TypeScript typings) to support `i18next-cli` ([i18next/i18next-cli#155](https://github.com/i18next/i18next-cli/pull/155))

---

#### 16.5.2

- fix: Type errors when you've declared a resources type [1899](https://github.com/i18next/react-i18next/issues/1899) via [1900](https://github.com/i18next/react-i18next/pull/1900)

---

#### 16.5.3

- fix: Trans named tags with underscore [1901](https://github.com/i18next/react-i18next/pull/1901)

---

#### 16.5.4

- fix: Overriding React component props not working [1902](https://github.com/i18next/react-i18next/pull/1902)

---

#### 16.5.5

- fix: prevent crash in `useSSR`, `getInitialProps` and `Translation` when no i18next instance is available (e.g. in monorepo setups with duplicate `react-i18next` copies) — now logs a clear warning instead of throwing [1604](https://github.com/i18next/react-i18next/discussions/1604)

---

#### 16.5.6

- fix: prevent crash in `useSSR` when `init()` hasn't been called before `useSSR` — now logs a warning instead of throwing [1604](https://github.com/i18next/react-i18next/discussions/1604)

---

#### 16.5.7

- fix: `<Trans>` component with `enableSelector: true` does not support multiple selectors for fallbacks [1907](https://github.com/i18next/react-i18next/issues/1907)

---

#### 16.5.8

- A selector function cannot be resolved without an i18n instance... returning empty string is safer than leaking the raw function reference. [1907](https://github.com/i18next/react-i18next/issues/1907)

---

#### 16.6.0

- warn when `t` is called before `ready` with `useSuspense: false` [1896](https://github.com/i18next/react-i18next/issues/1896)
- type-safe `values` prop on `<Trans />` component — interpolation variables are now inferred from the translation string when custom types are configured [1772](https://github.com/i18next/react-i18next/issues/1772)

---

#### 16.6.1

- feat(types): i18nKey of `<Trans i18nKey={sk} />` to accept a `SelectorKey` [2364](https://github.com/i18next/i18next/issues/2364)

---

#### 16.6.2

- feat(types): `useTranslation` now accepts selector functions as `keyPrefix` with full type-safe key narrowing when `enableSelector` is enabled [2367](https://github.com/i18next/i18next/issues/2367)

---

#### 16.6.3

- fix(types): merge `TransSelector` overloads into a single signature so `typeof Trans` remains extendable [1909](https://github.com/i18next/react-i18next/issues/1909)

---

#### 16.6.4

- allow TypeScript 6 as peer dependency [1910](https://github.com/i18next/react-i18next/issues/1910)

---

#### 16.6.5

- fix(types): selector keyPrefix overload in `useTranslation` no longer matches when `keyPrefix` is absent, fixing `defaultNS: false` with explicit `ns` option [2412](https://github.com/i18next/i18next/issues/2412)

---

#### 16.6.6

- fix(peer-deps): bump i18next peer dependency to `>= 25.10.9` to match required type exports (`ConstrainTarget`, `ApplyTarget`, `GetSource`) used by `TransSelector` [1911](https://github.com/i18next/react-i18next/issues/1911)


_Source: [CHANGELOG.md](https://github.com/i18next/react-i18next/blob/HEAD/CHANGELOG.md)_

---

