### PR TITLE
test: ensure unique node names in test factories

### DIFF
--- a/src/mocks/factories.ts
+++ b/src/mocks/factories.ts
@@ -9,10 +9,21 @@ import { faker } from '@faker-js/faker';
 import type { GQLFile, GQLFolder } from '../graphql/types';
 import { GQLNodeType } from '../graphql/types';
 
+// faker.system.fileName draws from a small dictionary, so generating many nodes
+// occasionally yields duplicate names. Tests query nodes by their exact name with
+// getByText, which then throws "found multiple elements". A monotonic suffix keeps
+// the realistic faker name while guaranteeing uniqueness across a single test run.
+let uniqueNodeNameCounter = 0;
+
+function uniqueNodeName(): string {
+	uniqueNodeNameCounter += 1;
+	return `${faker.system.fileName({ extensionCount: 0 })}-${uniqueNodeNameCounter}`;
+}
+
 export function createFile(file?: Partial<GQLFile>): GQLFile {
 	return {
 		id: faker.string.uuid(),
-		name: faker.system.fileName({ extensionCount: 0 }),
+		name: uniqueNodeName(),
 		created_at: faker.date.past().valueOf(),
 		updated_at: faker.date.recent().valueOf(),
 		type: faker.helpers.arrayElement(
@@ -29,7 +40,7 @@ export function createFile(file?: Partial<GQLFile>): GQLFile {
 export function createFolder(folder?: Partial<GQLFolder>): GQLFolder {
 	return {
 		id: faker.string.uuid(),
-		name: faker.system.fileName({ extensionCount: 0 }),
+		name: uniqueNodeName(),
 		created_at: faker.date.past().valueOf(),
 		updated_at: faker.date.recent().valueOf(),
 		type: GQLNodeType.Folder,


### PR DESCRIPTION
## Problem

The test suite is intermittently flaky: tests that look up a node by its exact
name fail with `TestingLibraryElementError: Found multiple elements with the text: …`.

It surfaces most visibly in `src/components/NodeList.test.tsx` (e.g. *should show
nodes of specific folderId*, *should do nothing when a file is double clicked*),
which renders a 24-node `firstPageNodes` set and then asserts each node with
`getByText(node.name)`.

## Root cause

`src/mocks/factories.ts` builds node names with `faker.system.fileName({ extensionCount: 0 })`.
That draws from a small dictionary (words like `which`, `till`), so across a
24-node set two nodes occasionally get the **same** name → `getByText` (exact
match) finds two elements and throws.

Two factors make it nasty:

- The set is generated **once at `describe` level**, so the collision persists
  across the configured `retry: 1` and fails **both** attempts.
- `faker` is not seeded, so whether a collision happens varies run-to-run
  (~5–10% under CPU load).

This is unrelated to any dependency. It was originally misattributed to an `msw`
bump during a dependency update; a 20× parallel stress run confirmed the failure
reproduces with the current dependencies and is purely a name-collision issue.

## Fix

Append a monotonic suffix to the generated node name, keeping a realistic faker
name while guaranteeing uniqueness within a run.

## Verification

- Full suite (with coverage): 103/103.
- `NodeList.test.tsx` 20× parallel stress run under load: **0/20 failures**
  (was 2/20 before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
