### PR TITLE
build: migrate to buildah (FQDN images + jenkins-lib-common@v2.10.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM backplane/jq:latest AS builder
+FROM --platform=$BUILDPLATFORM docker.io/backplane/jq:latest AS builder
 
 # Define path variables
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris" \
@@ -12,7 +12,7 @@ RUN mkdir -p "${WEB_PATH}" \
     && mv /tmp/dist/* "${WEB_PATH}"
 
 # Final stage - built for all target platforms
-FROM backplane/jq:latest
+FROM docker.io/backplane/jq:latest
 
 # Re-define path variable for final stage
 ENV IRIS_BASE_PATH="/opt/zextras/web/iris"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v2.4.3',
+    identifier: 'jenkins-lib-common@v2.10.0',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
## Buildah migration

Bump di `jenkins-lib-common` a **v2.10.0**, la cui unica feature è la sostituzione di Docker-in-Docker con **buildah** per le build container daemonless.

Buildah gira con `short-name-mode = "enforcing"`: davanti a un'immagine non completamente qualificata dovrebbe chiedere interattivamente quale registry usare, ma in CI non c'è TTY → la build fallisce con `short-name resolution enforced but cannot prompt without a TTY`.

### Modifiche
- **Jenkinsfile**: bump `jenkins-lib-common@v2.4.3` → `@v2.10.0`
- **Dockerfile**: qualifica la base image `backplane/jq:latest` → `docker.io/backplane/jq:latest` in entrambi gli stage

Stesso fix applicato in zextras/carbonio-tasks-ui#346 (parte della migrazione buildah org-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)