### PR TITLE
fix(codegen): update schema URL to renamed devel branch

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -12,7 +12,7 @@ import type { TypeScriptDocumentsPluginConfig } from '@graphql-codegen/typescrip
 const config: CodegenConfig = {
 	overwrite: true,
 	schema:
-		'https://raw.githubusercontent.com/zextras/carbonio-files-ce/refs/heads/develop/core/src/main/resources/api/public-schema.graphql',
+		'https://raw.githubusercontent.com/zextras/carbonio-files-ce/refs/heads/devel/core/src/main/resources/api/public-schema.graphql',
 	documents: 'src/graphql/queries/*.graphql',
 	generates: {
 		'src/graphql/schema-public.graphql': {

--- a/src/graphql/schema-public.ts
+++ b/src/graphql/schema-public.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */


### PR DESCRIPTION
## Summary

Il branch dello schema GraphQL nel repo `carbonio-files-ce` è stato rinominato da **`develop`** a **`devel`**, quindi `pnpm codegen` falliva con **404 Not Found**. Questa PR aggiorna l'URL dello schema in `codegen.ts` al branch corretto, ripristinando la pipeline di code generation.

## Cosa cambia

- `codegen.ts`: URL schema `…/refs/heads/develop/…` → `…/refs/heads/devel/…`
- File generati rigenerati con le versioni **attuali** del codegen (nessun bump di dipendenze): l'unico diff è l'anno SPDX di copyright (2025 → 2026), stampato dall'hook `eslint --fix` (eslint-plugin-notice) alla rigenerazione. **Nessun cambiamento di schema o di tipi.**

## Verification

- ✅ type-check · ✅ lint · ✅ test (103 test) · ✅ build
- ✅ `pnpm codegen` ora completa senza errori (prima: 404)
- ℹ️ verifica eseguita due volte (run parallela + pre-commit hook husky)

## Nota

Il bump major dei pacchetti `@graphql-codegen/*` (v7/v6) è stato **scorporato**: richiede una migrazione non banale (cambio default `enumsAsTypes`, enum duplicato tra i plugin `typescript`/`typescript-operations`, e campi nullable dei result type da opzionali a richiesti che impatta ~8 punti tra mock e test). Verrà affrontato come task dedicato.
