### PR TITLE
chore(deps): update dependency zextras/jenkins-lib-common to v4.1.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-common@v2.11.3',
+    identifier: 'jenkins-lib-common@v4.1.4',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',


### PR DESCRIPTION
Pin-only bump of `jenkins-lib-common` to `v4.1.4`. This version carries the Nexus mirror for the library retrieval. No pipeline parameters needed migration (repo does not use `uiPipeline(testScript:)` or `uploadStage(packages:)`).

Ref: https://zextras.atlassian.net/browse/IN-1168